### PR TITLE
Add fix of can't read user id.

### DIFF
--- a/functions/src/resolvers/map_resolvers.js
+++ b/functions/src/resolvers/map_resolvers.js
@@ -3,7 +3,11 @@ const tagResolvers = {
     createTime: async (tag, _, __) => tag.createTime.toDate().toString(),
     lastUpdateTime: async (tag, _, __) =>
       tag.lastUpdateTime.toDate().toString(),
-    createUser: async (tag, _, __) => ({ uid: tag.createUserId }),
+    createUser: async (tag, _, __) => ({
+      // TODO: `tag.createUserId` is old field name
+      // remove it if we clean the database
+      uid: tag.createUserId || tag.createUserID,
+    }),
     imageUrl: async (tag, _, { dataSources }) =>
       dataSources.firebaseAPI.getImageUrls({ tagID: tag.id }),
     statusHistory: async (tag, _, { dataSources }) =>


### PR DESCRIPTION
Some old use id data in firestore is store in the
field with old name: `createUserID`, add temporary fix
in resolver, so that resolver can get uid of ID if it can
not read `Id`. Remove it if the database is cleaned again.