### PR TITLE
Modify update action, only update the input field data

### DIFF
--- a/functions/src/__test__/graphql_integration.test.js
+++ b/functions/src/__test__/graphql_integration.test.js
@@ -254,7 +254,7 @@ describe('test graphql mutate', () => {
 
   test('test add tag data', async () => {
     const mutateTag = gql`
-      mutation tagAddTest($data: TagDataInput!) {
+      mutation tagAddTest($data: addTagDataInput!) {
         addNewTagData(data: $data) {
           tag {
             id
@@ -316,7 +316,7 @@ describe('test graphql mutate', () => {
 
   test('test update tag data', async () => {
     const mutateTag = gql`
-      mutation tagUpdateTest($tagId: ID!, $data: TagDataInput!) {
+      mutation tagUpdateTest($tagId: ID!, $data: updateTagDataInput!) {
         updateTagData(tagId: $tagId, data: $data) {
           id
           locationName
@@ -324,18 +324,12 @@ describe('test graphql mutate', () => {
         }
       }
     `;
+
+    // change field
     const latestDescription = 'latest changed update description';
     const data = {
-      ...fakeTagData,
-      coordinates: {
-        latitude: fakeTagData.coordinatesString.latitude,
-        longitude: fakeTagData.coordinatesString.longitude,
-      },
       description: latestDescription,
-      streetViewInfo: fakeTagData.streetViewInfo,
     };
-    delete data.status;
-    delete data.coordinatesString;
 
     // first add data to firestore
     const response = await addFakeDataToFirestore(firebaseAPIinstance);
@@ -352,7 +346,7 @@ describe('test graphql mutate', () => {
     const responseData = result.data.updateTagData;
     expect(responseData).toMatchObject({
       id: expect.any(String),
-      locationName: data.locationName,
+      locationName: fakeTagData.locationName,
       description: latestDescription,
     });
   });

--- a/functions/src/datasources/firebase.js
+++ b/functions/src/datasources/firebase.js
@@ -366,10 +366,12 @@ class FirebaseAPI extends DataSource {
       locationName,
       category,
       floor,
-      coordinates: new this.admin.firestore.GeoPoint(
-        parseFloat(coordinates.latitude),
-        parseFloat(coordinates.longitude)
-      ),
+      coordinates: coordinates
+        ? new this.admin.firestore.GeoPoint(
+            parseFloat(coordinates.latitude),
+            parseFloat(coordinates.longitude)
+          )
+        : undefined,
       // originally tagDetail
       lastUpdateTime: this.admin.firestore.FieldValue.serverTimestamp(),
       description,
@@ -399,8 +401,13 @@ class FirebaseAPI extends DataSource {
     if (action === 'update') {
       const refOfUpdateTag = tagGeoRef.doc(tagId);
 
+      // filter out not change data (undefined)
+      const tagDataUpdate = Object.keys(tagData)
+        .filter(key => tagData[key] !== undefined)
+        .reduce((obj, key) => ({ ...obj, [key]: tagData[key] }));
+
       // update tagData to server
-      await refOfUpdateTag.update(tagData);
+      await refOfUpdateTag.update(tagDataUpdate);
 
       return getDataFromTagDocRef(refOfUpdateTag.native);
     }

--- a/functions/src/schema/map_schema.js
+++ b/functions/src/schema/map_schema.js
@@ -89,10 +89,20 @@ const AddNewTagResponse = `type AddNewTagResponse {
   imageUploadUrl: [String]!
 }`;
 
-const TagDataInput = `input TagDataInput {
+const AddTagDataInput = `input addTagDataInput {
   locationName: String!
   category: CategoryInput!
   coordinates: CoordinateInput!
+  description: String
+  imageNumber: Int
+  floor: Int
+  streetViewInfo: StreetViewInput
+}`;
+
+const UpdateTagDataInput = `input updateTagDataInput {
+  locationName: String
+  category: CategoryInput
+  coordinates: CoordinateInput
   description: String
   imageNumber: Int
   floor: Int
@@ -133,7 +143,8 @@ module.exports = {
   updateUpVoteAction,
   updateUpVoteResponse,
   AddNewTagResponse,
-  TagDataInput,
+  AddTagDataInput,
+  UpdateTagDataInput,
   CoordinateInput,
   CategoryInput,
   StreetViewInput,

--- a/functions/src/schema/schema.js
+++ b/functions/src/schema/schema.js
@@ -12,7 +12,8 @@ const {
   updateUpVoteAction,
   updateUpVoteResponse,
   AddNewTagResponse,
-  TagDataInput,
+  AddTagDataInput,
+  UpdateTagDataInput,
   CoordinateInput,
   CategoryInput,
   StreetViewInput,
@@ -31,8 +32,8 @@ const Query = `type Query {
 
 const Mutation = `type Mutation {
   #tagImageUrlAdd(id: ID, imageUrl: [String]!): TagDetail!
-  addNewTagData(data: TagDataInput!): AddNewTagResponse
-  updateTagData(tagId: ID!, data: TagDataInput!): Tag!
+  addNewTagData(data: addTagDataInput!): AddNewTagResponse
+  updateTagData(tagId: ID!, data: updateTagDataInput!): Tag!
   updateTagStatus(tagId: ID!, statusName: String!, description: String): Status!
   addNewIntent(userIntent: String!, userAnswer: String!): String
   updateUpVoteStatus(tagId: ID!, action: updateUpVoteAction!): updateUpVoteResponse
@@ -55,7 +56,8 @@ const typeDefs = gql(
     updateUpVoteAction,
     updateUpVoteResponse,
     AddNewTagResponse,
-    TagDataInput,
+    AddTagDataInput,
+    UpdateTagDataInput,
     CoordinateInput,
     CategoryInput,
     StreetViewInput,


### PR DESCRIPTION
The data in the input will be update, other filed remain unchanged.
Split tagDataInput schema into add and update; all fields in the
 update input can be null.